### PR TITLE
aws ec2 support in orchard-provider-aws

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,17 @@ val akkaVersion = "2.6.14"
 val playJsonVersion = "2.8.1"
 val awsVersion = "2.17.+"
 
-val scalaTestArtifact = "org.scalatest" %% "scalatest" % "3.2.9" % Test
+val awsEc2            = "software.amazon.awssdk"     % "ec2"                      % awsVersion
+val awsEmr            = "software.amazon.awssdk"     % "emr"                      % awsVersion
+val awsSsm            = "software.amazon.awssdk"     % "ssm"                      % awsVersion
+val slick             =  "com.typesafe.slick"       %% "slick"                    % slickVersion
+val slickHikaricp     =  "com.typesafe.slick"       %% "slick-hikaricp"           % slickVersion
+val postgresql        =  "org.postgresql"            % "postgresql"               % "42.2.21"
+val playJson          =  "com.typesafe.play"        %% "play-json"                % playJsonVersion
+val akkaActor         =  "com.typesafe.akka"        %% "akka-actor-typed"         % akkaVersion
+val akkaTestkit       =  "com.typesafe.akka"        %% "akka-actor-testkit-typed" % akkaVersion % Test
+val scalaTestArtifact = "org.scalatest"             %% "scalatest"                % "3.2.9" % Test
+val scalaPlusPlay     = "org.scalatestplus.play"    %% "scalatestplus-play"       % "5.1.0" % Test
 
 lazy val commonSettings = Seq(
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint"), // , "-Xfatal-warnings"),
@@ -35,12 +45,12 @@ lazy val orchardCore = (project in file("orchard-core")).
   settings(
     name := "orchard-core",
     libraryDependencies ++= Seq(
-      "com.typesafe.slick" %% "slick" % slickVersion,
-      "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
-      "org.postgresql" % "postgresql" % "42.2.21",
-      "com.typesafe.play" %% "play-json" % playJsonVersion,
-      "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
-      "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaVersion % Test
+      slick,
+      slickHikaricp,
+      postgresql,
+      playJson,
+      akkaActor,
+      akkaTestkit
     )
   )
 
@@ -53,7 +63,7 @@ lazy val orchardWS = (project in file("orchard-ws")).
     buildInfoPackage := "com.salesforce.mce.orchard.ws",
     libraryDependencies ++= Seq(
       guice,
-      "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
+      scalaPlusPlay
     )
   ).
   dependsOn(orchardCore, orchardProviderAWS)
@@ -63,7 +73,9 @@ lazy val orchardProviderAWS = (project in file("orchard-provider-aws")).
   settings(
     name := "orchard-provider-aws",
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "emr" % awsVersion
+      awsEc2,
+      awsEmr,
+      awsSsm
     )
   ).
   dependsOn(orchardCore)

--- a/orchard-core/src/main/scala/com/salesforce/mce/orchard/system/actor/ActivityAttempt.scala
+++ b/orchard-core/src/main/scala/com/salesforce/mce/orchard/system/actor/ActivityAttempt.scala
@@ -117,7 +117,7 @@ object ActivityAttempt {
 
             result match {
               case Left(exp) =>
-                ps.ctx.log.error(s"ActivityAttempt ${ps.ctx.self} exption in creating task", exp)
+                ps.ctx.log.error(s"ActivityAttempt ${ps.ctx.self} exception in creating task", exp)
                 ps.database.sync(ps.query.setTerminated(Status.Failed, exp.getMessage()))
                 terminate(ps, Status.Failed)
               case Right((activityIO, attemptSpec)) =>

--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/Client.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/Client.scala
@@ -1,9 +1,12 @@
 package com.salesforce.mce.orchard.io.aws
 
+import software.amazon.awssdk.services.ec2.Ec2Client
 import software.amazon.awssdk.services.emr.EmrClient
+import software.amazon.awssdk.services.ssm.SsmClient
 
 object Client {
 
-  def emr() = EmrClient.create()
-
+  def ec2(): Ec2Client = Ec2Client.create()
+  def emr(): EmrClient = EmrClient.create()
+  def ssm(): SsmClient = SsmClient.create()
 }

--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/activity/Ec2Activity.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/activity/Ec2Activity.scala
@@ -1,0 +1,108 @@
+package com.salesforce.mce.orchard.io.aws.activity
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+import org.slf4j.LoggerFactory
+import play.api.libs.json.JsValue
+import software.amazon.awssdk.services.ssm.model._
+
+import com.salesforce.mce.orchard.io.ActivityIO
+import com.salesforce.mce.orchard.io.aws.Client
+import com.salesforce.mce.orchard.model.Status
+import com.salesforce.mce.orchard.system.util.InvalidJsonException
+
+abstract class Ec2Activity(
+  name: String,
+  ec2IstanceId: String
+) extends ActivityIO {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+  protected val RunShellScriptDocument = "AWS-RunShellScript"
+
+  protected def getComment(clazz: Class[_ <: Ec2Activity]): String = {
+    // ssm runCommand comment length must be <= 100
+    val comment = s"$name ${clazz.getName.split("\\.").last}"
+    comment.substring(0, math.min(comment.length, 100))
+  }
+
+  /**
+   * Ec2 related activities check progress the same way, thus this abstract class method to abstract the logic.
+   * Example extensions of this class include ShellCommandActivity and ShellScriptActivity
+   * @param commands  command-id wrt AWS SSM
+   * @return
+   */
+  private def getProgress(commands: Seq[String]) = {
+
+    logger.debug(s"getProgress: commands=$commands")
+    val client = Client.ssm()
+    val resp = client.listCommands(
+      ListCommandsRequest.builder().commandId(commands.head).instanceId(ec2IstanceId).build()
+    )
+    client.close()
+    val statuses = resp
+      .commands()
+      .asScala
+      .map { c =>
+        logger.debug(s"getProgress: command status=${c.status()}")
+        c.status() match {
+          case CommandStatus.IN_PROGRESS => Status.Running
+          case CommandStatus.PENDING => Status.Pending
+          case CommandStatus.FAILED => Status.Failed
+          case CommandStatus.SUCCESS => Status.Finished
+          case CommandStatus.CANCELLED => Status.Canceled
+          case CommandStatus.CANCELLING => Status.Canceling
+          case CommandStatus.TIMED_OUT => Status.Failed
+          case CommandStatus.UNKNOWN_TO_SDK_VERSION => Status.Failed
+          case _ => Status.Failed
+        }
+      }
+      .toSet
+
+    if (statuses.isEmpty || statuses.contains(Status.Failed))
+      Status.Failed
+    else if (statuses.contains(Status.Canceling))
+      Status.Canceling
+    else if (statuses.contains(Status.Canceled))
+      Status.Canceled
+    else if (statuses.contains(Status.Running))
+      Status.Running
+    else if (statuses.size == 1 && statuses.contains(Status.Finished))
+      Status.Finished
+    else
+      Status.Pending
+  }
+
+  override def getProgress(spec: JsValue): Either[Throwable, Status.Value] = spec
+    .validate[Seq[String]]
+    .fold(
+      invalid => Left(InvalidJsonException.raise(invalid)),
+      valid => Right(getProgress(valid))
+    )
+
+  /**
+   * Ec2 related activities terminate the same way, thus this abstract class method to abstract the logic.
+   * Example extensions of this class include ShellCommandActivity and ShellScriptActivity
+   * @param commands  command-id wrt AWS SSM
+   * @return
+   */
+  private def terminate(commands: Seq[String]) = {
+    logger.debug(s"terminate: commands=$commands")
+    val client = Client.ssm()
+    client.cancelCommand(
+      CancelCommandRequest.builder().commandId(commands.head).instanceIds(ec2IstanceId).build()
+    )
+    Status.Canceled
+  }
+
+  override def terminate(spec: JsValue): Either[Throwable, Status.Value] = spec
+    .validate[Seq[String]]
+    .fold(
+      { invalid => Left(InvalidJsonException.raise(invalid)) },
+      valid => Right(terminate(valid))
+    )
+
+  override def toString: String = {
+    s"Ec2Activity: name=$name ec2IstanceId=$ec2IstanceId.  ${super.toString}"
+  }
+
+}

--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/activity/ShellCommandActivity.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/activity/ShellCommandActivity.scala
@@ -1,0 +1,86 @@
+package com.salesforce.mce.orchard.io.aws.activity
+
+import java.time.{LocalDateTime, ZoneOffset}
+import java.time.temporal.ChronoUnit
+import scala.jdk.CollectionConverters.{MapHasAsJava, SeqHasAsJava}
+import scala.util.Try
+import org.slf4j.LoggerFactory
+import play.api.libs.json.{JsResult, JsValue, Json, Reads}
+import software.amazon.awssdk.services.ssm.model.SendCommandRequest
+import com.salesforce.mce.orchard.io.ActivityIO
+import com.salesforce.mce.orchard.io.aws.Client
+
+case class ShellCommandActivity(
+  name: String,
+  cmd: ShellCommandActivity.Command,
+  ec2InstanceId: String
+) extends Ec2Activity(name, ec2InstanceId) {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /**
+   * create activity via AWS SSM SendCommand to an ec2Instance
+   * @return  SSM command-id in a single entry list
+   */
+  override def create(): Either[Throwable, JsValue] = Try {
+
+    logger.debug(
+      s"create: name=$name ec2InstanceId=$ec2InstanceId cmd lines=${cmd.lines.mkString(" ")}."
+    )
+    cmd.lines.foreach(c => logger.debug(s"create command=$c"))
+
+    lazy val ts = LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MINUTES)
+    val client = Client.ssm()
+    val paraMap = Map(
+      "commands" -> cmd.lines.asJava,
+      "executionTimeout" -> List(cmd.executionTimeout.toString).asJava
+    )
+    val request =
+      SendCommandRequest
+        .builder()
+        .documentName(RunShellScriptDocument)
+        .instanceIds(ec2InstanceId)
+        .comment(getComment(getClass))
+        .parameters(paraMap.asJava)
+        .timeoutSeconds(cmd.deliveryTimeout)
+        .outputS3BucketName(cmd.outputS3BucketName)
+        .outputS3KeyPrefix(s"${cmd.outputS3KeyPrefix.stripPrefix("/")}/${name}_$ts")
+        .build()
+    val response = client.sendCommand(request)
+    client.close()
+    val command = response.command()
+    val commandId = command.commandId()
+    logger.debug(s"create: sendCommand commandId=$commandId command=${command.toString}")
+
+    Json.toJson(List(commandId))
+  }.toEither
+
+  override def toString: String = {
+    s"ShellCommandActivity: $name command=$cmd.  ${super.toString}"
+  }
+}
+
+object ShellCommandActivity {
+  case class Command(
+    lines: Seq[String],
+    outputS3BucketName: String,
+    outputS3KeyPrefix: String,
+    executionTimeout: Int = 3600,
+    deliveryTimeout: Int = 600
+  )
+
+  implicit val cmdReads: Reads[Command] = Json.reads[Command]
+
+  def decode(conf: ActivityIO.Conf): JsResult[ShellCommandActivity] = {
+    for {
+      cmd <- (conf.activitySpec \ "command").validate[ShellCommandActivity.Command]
+      ec2InstanceId <- (conf.resourceInstSpec \ "ec2InstanceId").validate[String]
+    } yield {
+      ShellCommandActivity(
+        s"${conf.workflowId}_act-${conf.activityId}_${conf.attemptId}",
+        cmd,
+        ec2InstanceId
+      )
+    }
+  }
+}

--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/activity/ShellScriptActivity.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/activity/ShellScriptActivity.scala
@@ -1,0 +1,95 @@
+package com.salesforce.mce.orchard.io.aws.activity
+
+import java.time.{LocalDateTime, ZoneOffset}
+import java.time.temporal.ChronoUnit
+import scala.jdk.CollectionConverters.{MapHasAsJava, SeqHasAsJava}
+import scala.util.Try
+import org.slf4j.LoggerFactory
+import play.api.libs.json.{JsResult, JsValue, Json, Reads}
+import software.amazon.awssdk.services.ssm.model.SendCommandRequest
+import com.salesforce.mce.orchard.io.ActivityIO
+import com.salesforce.mce.orchard.io.aws.Client
+
+case class ShellScriptActivity(
+  name: String,
+  script: ShellScriptActivity.Script,
+  ec2InstanceId: String
+) extends Ec2Activity(name, ec2InstanceId) {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /**
+   * create activity via AWS SSM SendCommand to an ec2Instance
+   * @return  SSM command-id in a single entry list
+   */
+  override def create(): Either[Throwable, JsValue] = Try {
+
+    logger.debug(s"create: name=$name ec2InstanceId=$ec2InstanceId script=$script")
+
+    lazy val ts = LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MINUTES)
+    val preRunInfo = s"cd ~ "
+    val pullScript = s"aws s3 cp ${script.scriptLocation} . "
+    val scriptFile = script.scriptLocation.split("/").last
+    val chmodScript = s"chmod +x ./$scriptFile"
+    val runScript = s" ./$scriptFile ${script.args.mkString(" ")}"
+    val commands =
+      List(preRunInfo, s"echo $pullScript", pullScript, chmodScript, s"echo $runScript", runScript)
+    commands.foreach(c => logger.debug(s"create: command=$c"))
+
+    val client = Client.ssm()
+    val paraMap = Map(
+      "commands" -> commands.asJava,
+      "executionTimeout" -> List(script.executionTimeout.toString).asJava
+    )
+    val request =
+      SendCommandRequest
+        .builder()
+        .documentName(RunShellScriptDocument)
+        .instanceIds(ec2InstanceId)
+        .comment(getComment(getClass))
+        .parameters(paraMap.asJava)
+        .timeoutSeconds(script.deliveryTimeout)
+        .outputS3BucketName(script.outputS3BucketName)
+        .outputS3KeyPrefix(s"${script.outputS3KeyPrefix.stripPrefix("/")}/${name}_$ts")
+        .build()
+    val response = client.sendCommand(request)
+    client.close()
+    val command = response.command()
+    val commandId = command.commandId()
+    logger.debug(s"create: sendCommand commandId=$commandId command=${command.toString}")
+
+    Json.toJson(List(commandId))
+  }.toEither
+
+  override def toString: String = {
+    s"ShellScriptActivity: $name script=$script.  ${super.toString}"
+  }
+
+}
+
+object ShellScriptActivity {
+  case class Script(
+    scriptLocation: String,
+    args: Seq[String],
+    outputS3BucketName: String,
+    outputS3KeyPrefix: String,
+    executionTimeout: Int = 3600,
+    deliveryTimeout: Int = 600
+  )
+
+  implicit val scriptReads: Reads[Script] = Json.reads[Script]
+
+  def decode(conf: ActivityIO.Conf): JsResult[ShellScriptActivity] = {
+    for {
+      script <- (conf.activitySpec \ "script").validate[ShellScriptActivity.Script]
+      ec2InstanceId <- (conf.resourceInstSpec \ "ec2InstanceId").validate[String]
+    } yield {
+      ShellScriptActivity(
+        s"${conf.workflowId}_act-${conf.activityId}_${conf.attemptId}",
+        script,
+        ec2InstanceId
+      )
+    }
+  }
+
+}

--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
@@ -1,0 +1,132 @@
+package com.salesforce.mce.orchard.io.aws.resource
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.util.Try
+
+import org.slf4j.LoggerFactory
+import play.api.libs.json.{JsResult, JsValue, Json, Reads, Writes}
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse
+import software.amazon.awssdk.services.ec2.model._
+
+import com.salesforce.mce.orchard.io.ResourceIO
+import com.salesforce.mce.orchard.io.aws.Client
+import com.salesforce.mce.orchard.model.Status
+
+case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  override def create(): Either[Throwable, JsValue] = Try {
+    logger.debug(
+      s"create: spec subnetId=${spec.subnetId} spec=$spec"
+    )
+    val client = Client.ec2()
+    val builder = RunInstancesRequest
+      .builder()
+      .imageId(spec.amiImageId)
+      .instanceType(spec.instanceType)
+      .minCount(1)
+      .maxCount(1)
+      .subnetId(spec.subnetId)
+      .iamInstanceProfile(
+        IamInstanceProfileSpecification.builder().name(spec.instanceProfile).build()
+      )
+    if (spec.spotInstance) {
+      logger.debug(s"create: spotInstance=true")
+      builder.instanceMarketOptions(
+        InstanceMarketOptionsRequest.builder().marketType(MarketType.SPOT).build()
+      )
+    }
+    val resp = client.runInstances(builder.build())
+    client.close()
+    if (logger.isDebugEnabled) {
+      resp
+        .instances()
+        .forEach { i =>
+          logger.debug(s"create: instanceId=${i.instanceId()}")
+        }
+    }
+    Json.toJson(Ec2Resource.InstSpec(resp.instances().asScala.head.instanceId()))
+  }.toEither
+
+  override def getStatus(instSpec: JsValue): Either[Throwable, Status.Value] = {
+    logger.debug(s"getStatus: instSpec=${instSpec.toString()}")
+    val client = Client.ec2()
+    val ec2InstanceId = (instSpec \ "ec2InstanceId").as[String]
+    val response: DescribeInstancesResponse = client.describeInstances(
+      DescribeInstancesRequest
+        .builder()
+        .instanceIds(ec2InstanceId)
+        .build()
+    )
+    val state = response
+      .reservations()
+      .asScala
+      .flatMap { r => r.instances().asScala.map { i => i.state().name() } }
+      .toList
+    client.close()
+    val res = state.nonEmpty match {
+      case true =>
+        state.head match {
+          case InstanceStateName.PENDING => Right(Status.Activating)
+          case InstanceStateName.RUNNING => Right(Status.Running)
+          case InstanceStateName.TERMINATED => Right(Status.Finished)
+          case InstanceStateName.STOPPING => Right(Status.Finished)
+          case InstanceStateName.STOPPED => Right(Status.Finished)
+          case InstanceStateName.SHUTTING_DOWN => Right(Status.Finished)
+          case InstanceStateName.UNKNOWN_TO_SDK_VERSION =>
+            Left(new Exception("UNKNOWN_TO_SDK_VERSION"))
+          case _ => Left(new Exception("UNKNOWN_TO_SDK_VERSION"))
+        }
+      case _ => Left(new Exception("UNKNOWN_TO_SDK_VERSION"))
+    }
+    logger.debug(s"getStatus: result = $res")
+    res
+  }
+
+  override def terminate(instSpec: JsValue): Either[Throwable, Status.Value] = Try {
+    logger.debug(s"terminate: instSpec=${instSpec.toString()}")
+    val client = Client.ec2()
+    val id = (instSpec \ "ec2InstanceId").as[String]
+    val describeResponse =
+      client.describeInstances(DescribeInstancesRequest.builder().instanceIds(id).build())
+    val instanceLifecycle = describeResponse
+      .reservations()
+      .asScala
+      .flatMap { _.instances().asScala.map(_.instanceLifecycleAsString()) }
+      .head
+    logger.debug(s"terminate: instanceLifecycle=$instanceLifecycle")
+    if (!"spot".equals(instanceLifecycle)) { // default setting spot instance can be terminated (not stopped)
+      client.stopInstances(StopInstancesRequest.builder().instanceIds(id).build())
+    }
+    client.terminateInstances(TerminateInstancesRequest.builder().instanceIds(id).build())
+    client.close()
+    logger.debug(s"terminate: stopped and terminated instanceId=$id")
+    Status.Finished
+  }.toEither
+
+}
+
+object Ec2Resource {
+  case class InstSpec(ec2InstanceId: String)
+
+  implicit val instSpecWrites: Writes[InstSpec] = Json.writes[InstSpec]
+  implicit val instSpecReads: Reads[InstSpec] = Json.reads[InstSpec]
+
+  case class Spec(
+    amiImageId: String,
+    subnetId: String,
+    instanceType: String,
+    instanceProfile: String,
+    spotInstance: Boolean
+  )
+
+  implicit val specReads: Reads[Spec] = Json.reads[Spec]
+
+  def decode(conf: ResourceIO.Conf): JsResult[Ec2Resource] = conf.resourceSpec
+    .validate[Spec]
+    .map { spec =>
+      Ec2Resource.apply(s"${conf.workflowId}_rsc-${conf.resourceId}_${conf.instanceId}", spec)
+    }
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.6"
+ThisBuild / version := "0.2.7"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.7"
+ThisBuild / version := "0.3.0"


### PR DESCRIPTION
io provider with AWS EC2.

In summary, the logic relies on AWS SSM (systems manager) service to launch EC2 instances, and run commands on them.  SSM provides the logging to S3, and various status tracking utility.

Two activities relating to EC2 resource are supported, they extend Ec2Activity abstract class, which extends the orchard ActivityIO trait
- ShellCommandActivity
- ShellScriptActivity

risk: low