### PR TITLE
io provider aws ec2 resource, getStatus() checking SSM visibility

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.5.0"
+ThisBuild / version := "0.5.1"


### PR DESCRIPTION
Change to io provider aws ec2 resource, getStatus() checking SSM visibility

In the time gap when an Ec2 instance is created, and SSM service is not aware of the new instance yet, if an activity attempt is executed on the ec2 instance, the following error would occur without this change.

 [error] 2022-05-27 14:49:15,686 c.s.m.o.s.a.ActivityAttempt$ - ActivityAttempt Actor[akka://application/user/orchard-system/wf-2ddb477a-52bc-419b-8b8b-86749e7df124/act-activityId_2/attempt-1#-1267839591] exception in creating task

software.amazon.awssdk.services.ssm.model.InvalidInstanceIdException: Instances [[i-04a8d2699077682b1]] not in a valid state for account 802707170857 (Service: Ssm, Status Code: 400, Request ID: 695a92b3-e94f-490b-9b19-b7b14b6bb7a5)