### PR TITLE
feat!: Remove static AWS credentials

### DIFF
--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/ProviderSettings.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/ProviderSettings.scala
@@ -16,8 +16,6 @@ case class ProviderSettings(config: Config) {
   }
 
   lazy val loggingUri = getConfigString("aws.logging.uri")
-  lazy val awsAccessKeyId = getConfigString("aws.static.credentials.accessKeyId")
-  lazy val awsSecretKey = getConfigString("aws.static.credentials.secretKey")
   lazy val awsClientRegion = getConfigString("aws.client.region")
   lazy val awsAssumeRoleArn = getConfigString("aws.assume.role.arn")
 }


### PR DESCRIPTION
BREAKING CHANGE: credentials are now sourced via DefaultCredentialsProvider