### PR TITLE
log info when ssm can't see created ec2

### DIFF
--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
@@ -118,7 +118,9 @@ case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO 
             case InstanceStateName.RUNNING =>
               isSsmVisible(Json.toJson(Ec2Resource.InstSpec(ec2InstanceId))) match {
                 case true => Right(Status.Running)
-                case _ => Right(Status.Activating)
+                case _ =>
+                  logger.info(s"ec2InstanceId $ec2InstanceId isSsmVisible=false")
+                  Right(Status.Activating)
               }
             case InstanceStateName.TERMINATED => Right(Status.Finished)
             case InstanceStateName.STOPPING => Right(Status.Finished)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.12.0"
+ThisBuild / version := "0.12.1"


### PR DESCRIPTION

In a test run of about 190 ec2 resource activities, we see about 10% of ec2 resourceInstance log saying activating for about 8 hours, then get terminated; the other 90% get to running status in seconds.  

Add logging to help identify situations when ec2 resource created, but ssm does not list it.  