### PR TITLE
Ec2Resource ssm list instance with filter

### DIFF
--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
@@ -12,6 +12,10 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
 import org.slf4j.LoggerFactory
 import play.api.libs.json._
 import software.amazon.awssdk.services.ec2.model._
+import software.amazon.awssdk.services.ssm.model.{
+  DescribeInstanceInformationRequest,
+  InstanceInformationStringFilter
+}
 
 import com.salesforce.mce.orchard.io.aws.Client
 import com.salesforce.mce.orchard.io.ResourceIO
@@ -77,18 +81,24 @@ case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO 
    * @return Boolean SSM has visibility to the EC2 instance
    */
   private def isSsmVisible(instSpec: JsValue): Boolean = {
+    val instanceId = (instSpec \ "ec2InstanceId").as[String]
     val ssmClient = Client.ssm()
-    val isVisible =
+    val infoReq = DescribeInstanceInformationRequest
+      .builder()
+      .filters(
+        InstanceInformationStringFilter.builder().key("InstanceIds").values(instanceId).build()
+      )
+      .build()
+    val resultSet =
       ssmClient
-        .describeInstanceInformation()
+        .describeInstanceInformation(infoReq)
         .instanceInformationList()
         .asScala
         .map(_.instanceId())
         .toSet
-        .contains((instSpec \ "ec2InstanceId").as[String])
         .retry()
     ssmClient.close()
-    isVisible
+    resultSet.nonEmpty
   }
 
   override def getStatus(instSpec: JsValue): Either[Throwable, Status.Value] = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.13.0"
+ThisBuild / version := "0.13.1"


### PR DESCRIPTION

To deal with the Ec2Resource intermittent error (about 10%), Ec2Resourcce isSsmVisibile() when doing describeInstanceInformation refactored with a filter on the specific instanceId to match.  Smaller and more exact response payload would do away with potentially some paginated result that may be missing the target instanceId on the first page.  

risk:low