### PR TITLE
Ec2Resource checks instanceStatus when isSsmVisible is false

### DIFF
--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
@@ -120,12 +120,10 @@ case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO 
     val response = client.describeInstanceStatus(request)
     client.close()
     val status = response.instanceStatuses().asScala
-    status.isEmpty match {
-      case true =>
-        Left(new Exception(s"Ec2 instance $ec2InstanceId describeInstanceStatus failed."))
-      case _ =>
-        val instanceStatus = status.head.instanceStatus().status()
-        val systemStatus = status.head.systemStatus().status()
+    status.toList match {
+      case sts :: _ =>
+        val instanceStatus = sts.instanceStatus().status()
+        val systemStatus = sts.systemStatus().status()
         if (!GoodSummaryStatuses.contains(instanceStatus)) {
           Left(
             new Exception(
@@ -144,6 +142,7 @@ case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO 
           )
           Right(Status.Activating)
         }
+      case _ => Left(new Exception(s"Ec2 instance $ec2InstanceId describeInstanceStatus failed."))
     }
   }
 

--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
@@ -77,10 +77,10 @@ case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO 
   }
 
   /**
-   * @param instSpec holds ec2InstanceId
+   * @param ec2InstanceId ec2InstanceId
    * @return Boolean SSM has visibility to the EC2 instance
    */
-  private def isSsmVisible(instSpec: JsValue): Boolean = {
+  private def isSsmVisible(ec2InstanceId: String): Boolean = {
     val ssmClient = Client.ssm()
     val infoReq = DescribeInstanceInformationRequest
       .builder()
@@ -88,7 +88,7 @@ case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO 
         InstanceInformationStringFilter
           .builder()
           .key("InstanceIds")
-          .values((instSpec \ "ec2InstanceId").as[String])
+          .values(ec2InstanceId)
           .build()
       )
       .build()
@@ -102,6 +102,49 @@ case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO 
         .retry()
     ssmClient.close()
     resultSet.nonEmpty
+  }
+
+  final val GoodSummaryStatuses = Set(SummaryStatus.INITIALIZING, SummaryStatus.OK)
+
+  /**
+   * when ssm does not yet have visibility to ec2, it could be initializing phase of the ec2 instance,
+   * or it could the ec2 has instanceStatus impaired.
+   * getStatus() performs this check to fail early in case the initialized ec2 instance status has issues,
+   * and the ResourceInstance logic can move on to the next attempt if available
+   * @param ec2InstanceId  ec2 instance id
+   * @return
+   */
+  def describeEc2Status(ec2InstanceId: String): Either[Throwable, Status.Value] = {
+    val client = Client.ec2()
+    val request = DescribeInstanceStatusRequest.builder().instanceIds(ec2InstanceId).build()
+    val response = client.describeInstanceStatus(request)
+    client.close()
+    val status = response.instanceStatuses().asScala
+    status.isEmpty match {
+      case true =>
+        Left(new Exception(s"Ec2 instance $ec2InstanceId describeInstanceStatus failed."))
+      case _ =>
+        val instanceStatus = status.head.instanceStatus().status()
+        val systemStatus = status.head.systemStatus().status()
+        if (!GoodSummaryStatuses.contains(instanceStatus)) {
+          Left(
+            new Exception(
+              s"Ec2 instance $ec2InstanceId instanceStatus=$instanceStatus."
+            )
+          )
+        } else if (!GoodSummaryStatuses.contains(status.head.systemStatus().status())) {
+          Left(
+            new Exception(
+              s"Ec2 instance $ec2InstanceId systemStatus=$systemStatus."
+            )
+          )
+        } else {
+          logger.debug(
+            s"Ec2 $ec2InstanceId instanceStatus=${instanceStatus.toString} systemStatus=${systemStatus.toString}"
+          )
+          Right(Status.Activating)
+        }
+    }
   }
 
   override def getStatus(instSpec: JsValue): Either[Throwable, Status.Value] = {
@@ -129,11 +172,11 @@ case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO 
           state.head match {
             case InstanceStateName.PENDING => Right(Status.Activating)
             case InstanceStateName.RUNNING =>
-              isSsmVisible(Json.toJson(Ec2Resource.InstSpec(ec2InstanceId))) match {
+              isSsmVisible(ec2InstanceId) match {
                 case true => Right(Status.Running)
                 case _ =>
                   logger.info(s"ec2InstanceId $ec2InstanceId isSsmVisible=false")
-                  Right(Status.Activating)
+                  describeEc2Status(ec2InstanceId)
               }
             case InstanceStateName.TERMINATED => Right(Status.Finished)
             case InstanceStateName.STOPPING => Right(Status.Finished)

--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/Ec2Resource.scala
@@ -125,12 +125,14 @@ case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO 
         val instanceStatus = sts.instanceStatus().status()
         val systemStatus = sts.systemStatus().status()
         if (!GoodSummaryStatuses.contains(instanceStatus)) {
+          logger.info(s"Ec2 instance $ec2InstanceId instanceStatus=$instanceStatus}")
           Left(
             new Exception(
               s"Ec2 instance $ec2InstanceId instanceStatus=$instanceStatus."
             )
           )
-        } else if (!GoodSummaryStatuses.contains(status.head.systemStatus().status())) {
+        } else if (!GoodSummaryStatuses.contains(systemStatus)) {
+          logger.info(s"Ec2 instance $ec2InstanceId systemStatus=$systemStatus")
           Left(
             new Exception(
               s"Ec2 instance $ec2InstanceId systemStatus=$systemStatus."
@@ -138,7 +140,7 @@ case class Ec2Resource(name: String, spec: Ec2Resource.Spec) extends ResourceIO 
           )
         } else {
           logger.debug(
-            s"Ec2 $ec2InstanceId instanceStatus=${instanceStatus.toString} systemStatus=${systemStatus.toString}"
+            s"Ec2 $ec2InstanceId instanceStatus=${instanceStatus} systemStatus=$systemStatus"
           )
           Right(Status.Activating)
         }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.14.0"
+ThisBuild / version := "0.14.1"


### PR DESCRIPTION
Based on feedback from an aws support case wrt SSM visibility to Ec2 instances that are running based on `describeInstances`, the ec2 instance status could be `impaired`, then SSM would not see the ec2 instances.  

Adding check for ec2 `describeInstanceStatus` when ssm visibility is false, and return Left exception for the resourceInstance attempt to fail early, thus be able to move on next attempt if available.  Otherwise, the current logic without the check would keep trying until terminate after 8 hours even the ec2 instance status is impaired.