### PR TITLE
OrchardSystem with SupervisorStrategy.restart

### DIFF
--- a/orchard-core/src/main/scala/com/salesforce/mce/orchard/system/OrchardSystem.scala
+++ b/orchard-core/src/main/scala/com/salesforce/mce/orchard/system/OrchardSystem.scala
@@ -55,73 +55,77 @@ object OrchardSystem {
     query: WorkflowManagerQuery,
     timers: TimerScheduler[Msg],
     workflows: Map[String, ActorRef[WorkflowMgr.Msg]]
-  ): Behavior[Msg] = Behaviors.receiveMessage[Msg] {
+  ): Behavior[Msg] = Behaviors
+    .receiveMessage[Msg] {
 
-    case ActivateMsg(workflowId) =>
-      ctx.log.info(s"${ctx.self} Received ActivateMsg($workflowId)")
-      if (workflows.contains(workflowId)) {
-        ctx.log.warn(s"${ctx.self} workflow $workflowId is already active")
+      case ActivateMsg(workflowId) =>
+        ctx.log.info(s"${ctx.self} Received ActivateMsg($workflowId)")
+        if (workflows.contains(workflowId)) {
+          ctx.log.warn(s"${ctx.self} workflow $workflowId is already active")
+          Behaviors.same
+        } else {
+          if (database.sync(query.get(workflowId)).isEmpty)
+            database.sync(query.manage(workflowId))
+          else
+            database.sync(query.checkin(Set(workflowId)))
+          val workflowMgr = ctx.spawn(WorkflowMgr.apply(database, workflowId), workflowId)
+          ctx.watchWith(workflowMgr, WorkflowTerminated(workflowId))
+          apply(ctx, database, query, timers, workflows + (workflowId -> workflowMgr))
+        }
+
+      case WorkflowTerminated(workflowId) =>
+        ctx.log.info(s"${ctx.self} Received WorkflowTerminated($workflowId)")
+        apply(ctx, database, query, timers, workflows - workflowId)
+
+      case ScanCanceling =>
+        ctx.log.debug(s"${ctx.self} Received ScanCanceling")
+        val cancelings = database.sync(WorkflowQuery.filterByStatus(Status.Canceling))
+        for {
+          workflow <- cancelings
+          workflowMgr <- workflows.get(workflow.id)
+        } workflowMgr ! WorkflowMgr.CancelWorkflow
+        timers.startSingleTimer(ScanCanceling, CancelingScanDelay)
         Behaviors.same
-      } else {
-        if (database.sync(query.get(workflowId)).isEmpty)
-          database.sync(query.manage(workflowId))
-        else
-          database.sync(query.checkin(Set(workflowId)))
-        val workflowMgr = ctx.spawn(WorkflowMgr.apply(database, workflowId), workflowId)
-        ctx.watchWith(workflowMgr, WorkflowTerminated(workflowId))
-        apply(ctx, database, query, timers, workflows + (workflowId -> workflowMgr))
-      }
 
-    case WorkflowTerminated(workflowId) =>
-      ctx.log.info(s"${ctx.self} Received WorkflowTerminated($workflowId)")
-      apply(ctx, database, query, timers, workflows - workflowId)
+      case HeartBeat =>
+        ctx.log.debug(s"${ctx.self} Received HeartBeat")
+        database.sync(query.checkin(workflows.keySet))
+        timers.startSingleTimer(HeartBeat, HeartBeatDelay)
+        Behaviors.same
 
-    case ScanCanceling =>
-      ctx.log.debug(s"${ctx.self} Received ScanCanceling")
-      val cancelings = database.sync(WorkflowQuery.filterByStatus(Status.Canceling))
-      for {
-        workflow <- cancelings
-        workflowMgr <- workflows.get(workflow.id)
-      } workflowMgr ! WorkflowMgr.CancelWorkflow
-      timers.startSingleTimer(ScanCanceling, CancelingScanDelay)
+      case AdoptOrphanWorkflows =>
+        ctx.log.info(s"${ctx.self} Received AdoptOrphanWorkflows")
+        database
+          .sync(query.getOrhpanWorkflows(5.minutes, 1.day))
+          .flatMap {
+            case (wf, Some(wm)) =>
+              if (
+                database.sync(new WorkflowManagerQuery(wm.managerId).delete(wm.workflowId)) > 0 &&
+                database.sync(query.manage(wf.id)) > 0
+              ) {
+
+                Some(wf.id)
+              } else {
+                None
+              }
+            case (wf, None) =>
+              if (database.sync(query.manage(wf.id)) > 0) {
+                Some(wf.id)
+              } else {
+                None
+              }
+          }
+          .foreach { wfId =>
+            ctx.log.info(s"${ctx.self} Adopt workflow ${wfId}")
+            ctx.self ! ActivateMsg(wfId)
+          }
+
+        timers.startSingleTimer(AdoptOrphanWorkflows, CheckAdoptionDelay)
+        Behaviors.same
+
+    }
+    .receiveSignal { case (_, signal) => // log PreRestart
+      ctx.log.info(s"${ctx.self} receiveSignal ${signal.toString}")
       Behaviors.same
-
-    case HeartBeat =>
-      ctx.log.debug(s"${ctx.self} Received HeartBeat")
-      database.sync(query.checkin(workflows.keySet))
-      timers.startSingleTimer(HeartBeat, HeartBeatDelay)
-      Behaviors.same
-
-    case AdoptOrphanWorkflows =>
-      ctx.log.info(s"${ctx.self} Received AdoptOrphanWorkflows")
-      database
-        .sync(query.getOrhpanWorkflows(5.minutes, 1.day))
-        .flatMap {
-          case (wf, Some(wm)) =>
-            if (
-              database.sync(new WorkflowManagerQuery(wm.managerId).delete(wm.workflowId)) > 0 &&
-              database.sync(query.manage(wf.id)) > 0
-            ) {
-
-              Some(wf.id)
-            } else {
-              None
-            }
-          case (wf, None) =>
-            if (database.sync(query.manage(wf.id)) > 0) {
-              Some(wf.id)
-            } else {
-              None
-            }
-        }
-        .foreach { wfId =>
-          ctx.log.info(s"${ctx.self} Adopt workflow ${wfId}")
-          ctx.self ! ActivateMsg(wfId)
-        }
-
-      timers.startSingleTimer(AdoptOrphanWorkflows, CheckAdoptionDelay)
-      Behaviors.same
-
-  }
-
+    }
 }

--- a/orchard-core/src/main/scala/com/salesforce/mce/orchard/system/OrchardSystem.scala
+++ b/orchard-core/src/main/scala/com/salesforce/mce/orchard/system/OrchardSystem.scala
@@ -93,13 +93,15 @@ object OrchardSystem {
       Behaviors.same
 
     case AdoptOrphanWorkflows =>
-      ctx.log.debug(s"${ctx.self} Received AdoptOrphanWorkflows")
+      ctx.log.info(s"${ctx.self} Received AdoptOrphanWorkflows")
       database
         .sync(query.getOrhpanWorkflows(5.minutes, 1.day))
         .flatMap {
           case (wf, Some(wm)) =>
-            if (database.sync(new WorkflowManagerQuery(wm.managerId).delete(wm.workflowId)) > 0 &&
-              database.sync(query.manage(wf.id)) > 0) {
+            if (
+              database.sync(new WorkflowManagerQuery(wm.managerId).delete(wm.workflowId)) > 0 &&
+              database.sync(query.manage(wf.id)) > 0
+            ) {
 
               Some(wf.id)
             } else {

--- a/orchard-ws/app/services/OrchardSystemService.scala
+++ b/orchard-ws/app/services/OrchardSystemService.scala
@@ -9,19 +9,42 @@ package services
 
 import javax.inject._
 
+import scala.concurrent.duration._
+import scala.util.{Success, Try}
+
 import akka.actor.ActorSystem
 import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
+import com.typesafe.config.{Config, ConfigFactory}
 
 import com.salesforce.mce.orchard.system.OrchardSystem
 
 @Singleton
 class OrchardSystemService @Inject() (actorSystem: ActorSystem, databaseService: DatabaseService) {
+
+  private val config: Config = ConfigFactory.load()
+  private val restartMaxNrOfRetries: Int = Try {
+    config.getInt("orchard.system.restart-num-of-retries")
+  } match {
+    case Success(x) => x
+    case _ => 10
+  }
+  private val restartTimeRange: FiniteDuration = Try {
+    config.getInt("orchard.system.restart-time-range")
+  } match {
+    case Success(x) => x.seconds
+    case _ => 60.seconds
+  }
+
   private val supervisedOrchardSystem: Behavior[OrchardSystem.Msg] =
     Behaviors
       .supervise(OrchardSystem.apply(databaseService.orchardDB))
-      .onFailure[Exception](SupervisorStrategy.restart)
+      .onFailure(
+        SupervisorStrategy.restart
+          .withLimit(maxNrOfRetries = restartMaxNrOfRetries, withinTimeRange = restartTimeRange)
+      )
+
   val orchard: ActorRef[OrchardSystem.Msg] =
     actorSystem.spawn(supervisedOrchardSystem, "orchard-system")
 }

--- a/orchard-ws/app/services/OrchardSystemService.scala
+++ b/orchard-ws/app/services/OrchardSystemService.scala
@@ -10,40 +10,46 @@ package services
 import javax.inject._
 
 import scala.concurrent.duration._
-import scala.util.{Success, Try}
 
 import akka.actor.ActorSystem
 import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
-import com.typesafe.config.{Config, ConfigFactory}
+import play.api.Configuration
 
 import com.salesforce.mce.orchard.system.OrchardSystem
 
 @Singleton
-class OrchardSystemService @Inject() (actorSystem: ActorSystem, databaseService: DatabaseService) {
+class OrchardSystemService @Inject() (
+  actorSystem: ActorSystem,
+  databaseService: DatabaseService,
+  conf: Configuration
+) {
 
-  private val config: Config = ConfigFactory.load()
-  private val restartMaxNrOfRetries: Int = Try {
-    config.getInt("orchard.system.restart-num-of-retries")
-  } match {
-    case Success(x) => x
-    case _ => 10
-  }
-  private val restartTimeRange: FiniteDuration = Try {
-    config.getInt("orchard.system.restart-time-range")
-  } match {
-    case Success(x) => x.seconds
-    case _ => 60.seconds
-  }
+  val numRetriesAndTimeRange = for {
+    n <- conf.getOptional[Int]("orchard.system.restart-num-of-retries")
+    t <- conf.getOptional[Long]("orchard.system.restart-time-range")
+  } yield (n, t)
 
   private val supervisedOrchardSystem: Behavior[OrchardSystem.Msg] =
-    Behaviors
-      .supervise(OrchardSystem.apply(databaseService.orchardDB))
-      .onFailure(
-        SupervisorStrategy.restart
-          .withLimit(maxNrOfRetries = restartMaxNrOfRetries, withinTimeRange = restartTimeRange)
-      )
+    if (numRetriesAndTimeRange.isEmpty) {
+      Behaviors
+        .supervise(OrchardSystem.apply(databaseService.orchardDB))
+        .onFailure(
+          SupervisorStrategy.restart
+        )
+    } else {
+      val (restartMaxNrOfRetries, restartTimeRange) = numRetriesAndTimeRange.get
+      Behaviors
+        .supervise(OrchardSystem.apply(databaseService.orchardDB))
+        .onFailure(
+          SupervisorStrategy.restart
+            .withLimit(
+              maxNrOfRetries = restartMaxNrOfRetries,
+              withinTimeRange = restartTimeRange.seconds
+            )
+        )
+    }
 
   val orchard: ActorRef[OrchardSystem.Msg] =
     actorSystem.spawn(supervisedOrchardSystem, "orchard-system")

--- a/orchard-ws/conf/application.conf
+++ b/orchard-ws/conf/application.conf
@@ -30,8 +30,8 @@ orchard.auth = {
 }
 
 orchard.system = {
-    restart-num-of-retries = 10
-    restart-time-range = 60 # time unit seconds
+    restart-num-of-retries = 30
+    restart-time-range = 1800 # 1800 seconds = 30 minutes, trying every minute for half hour
 }
 
 ## Akka

--- a/orchard-ws/conf/application.conf
+++ b/orchard-ws/conf/application.conf
@@ -29,6 +29,11 @@ orchard.auth = {
     ttl = 10
 }
 
+orchard.system = {
+    restart-num-of-retries = 10
+    restart-time-range = 60 # time unit seconds
+}
+
 ## Akka
 # https://www.playframework.com/documentation/latest/ScalaAkka#Configuration
 # https://www.playframework.com/documentation/latest/JavaAkka#Configuration

--- a/orchard-ws/conf/application.conf
+++ b/orchard-ws/conf/application.conf
@@ -30,8 +30,9 @@ orchard.auth = {
 }
 
 orchard.system = {
-    restart-num-of-retries = 30
-    restart-time-range = 1800 # 1800 seconds = 30 minutes, trying every minute for half hour
+    restart-min-backoff-seconds = 1
+    restart-max-backoff-seconds = 3600
+    restart-jitter-probability = 0.1 # between 0 and 1
 }
 
 ## Akka

--- a/orchard-ws/conf/logback.xml
+++ b/orchard-ws/conf/logback.xml
@@ -12,7 +12,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%date{yyyy-MM-dd HH:mm:ss ZZZZ} %coloredLevel %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.14.2"
+ThisBuild / version := "0.14.3"


### PR DESCRIPTION

Add SupervisorStrategy to restart the OrchardSystem actor, based on this akka documentation (https://doc.akka.io/docs/akka/2.6/typed/fault-tolerance.html#supervision).

This is to handle in case the postgres connection is lost, the OrchardSystem actor now being supervised can restart itself.  