### PR TITLE
Upgrade jackson to 2.21.2 for sonatype-2026-000642

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,8 @@ val slickVersion = "3.5.2"
 // make sure this is the same as the playWS's dependency
 val pekkoVersion = "1.0.3"
 val playJsonVersion = "3.0.6"
-val jacksonVersion = "2.18.6"
+val jacksonVersion = "2.21.2"
+val jacksonAnnotationsVersion = "2.21"
 val awsVersion = "2.42.+"
 val stubbornVersion = "3.1.0"
 val prometheusVersion = "0.16.0"
@@ -70,7 +71,7 @@ lazy val orchardCore = (project in file("orchard-core")).
       // Force Jackson version for consistency across all modules
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonAnnotationsVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
     )
@@ -119,7 +120,7 @@ lazy val orchardProviderAWS = (project in file("orchard-provider-aws")).
       // Force Jackson version to match security requirements
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonAnnotationsVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
     )


### PR DESCRIPTION
The previous bump to 2.18.6 was insufficient — the fix requires jackson-core >= 2.21.1. jackson-annotations uses a separate version (2.21) as the annotations artifact no longer publishes patch releases in the 2.20+ line.