### PR TITLE
add priority to EMR instance type config

### DIFF
--- a/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/EmrResource.scala
+++ b/orchard-provider-aws/src/main/scala/com/salesforce/mce/orchard/io/aws/resource/EmrResource.scala
@@ -101,6 +101,7 @@ case class EmrResource(
                                 .instanceType(i.instanceType)
                               i.bidPrice.foldLeft(itcBuilder)(_.bidPrice(_))
                               i.weightedCapacity.foldLeft(itcBuilder)(_.weightedCapacity(_))
+                              i.priority.foldLeft(itcBuilder)(_.priority(_))
                               itcBuilder.build()
                             }: _*)
                           if (lastAttempt && useOnDemandOnLastAttempt || c.targetSpotCapacity.isEmpty) {
@@ -258,7 +259,8 @@ object EmrResource {
   case class InstanceTypeConfig(
     instanceType: String,
     bidPrice: Option[String],
-    weightedCapacity: Option[Int]
+    weightedCapacity: Option[Int],
+    priority: Option[Double]
   )
   implicit val instanceTypeConfigReads: Reads[InstanceTypeConfig] =
     Json.reads[InstanceTypeConfig]

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.29.5"
+ThisBuild / version := "0.29.6"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.29.6"
+ThisBuild / version := "0.30.0"


### PR DESCRIPTION
We'd like to prioritize the instance types in the instance fleet