### PR TITLE
Bump logback-classic to 1.5.35 (CVE-2026-13006)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ val pekkoTestkit      = "org.apache.pekko"        %% "pekko-actor-testkit-typed"
 
 val scalaTestArtifact = "org.scalatest"             %% "scalatest"                % "3.2.19" % Test
 val scalaPlusPlay     = "org.scalatestplus.play"    %% "scalatestplus-play"       % "7.0.1" % Test
-val logback           = "ch.qos.logback"             % "logback-classic"          % "1.5.32"
+val logback           = "ch.qos.logback"             % "logback-classic"          % "1.5.35"
 val stubbornArtifact  = "com.krux"                  %% "stubborn"                 % stubbornVersion
 val prometheusClient  = "io.prometheus"              % "simpleclient"             % prometheusVersion
 val prometheusCommon  = "io.prometheus"              % "simpleclient_common"      % prometheusVersion

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.30.2"
+ThisBuild / version := "0.30.3"


### PR DESCRIPTION
logback 1.5.32 is vulnerable to CVE-2026-13006 (arbitrary code execution via conditional configuration + Janino). Fixed in 1.5.35. Bump version.sbt patch so the new artifact publishes.