### PR TITLE
Bump AWS SDK to 2.54.5 and Jackson to 2.21.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ val slickVersion = "3.5.2"
 // make sure this is the same as the playWS's dependency
 val pekkoVersion = "1.0.3"
 val playJsonVersion = "3.0.6"
-val jacksonVersion = "2.21.5"
+val jacksonVersion = "2.21.6"
 val jacksonAnnotationsVersion = "2.21"
-val awsVersion = "2.47.5"
+val awsVersion = "2.54.5"
 val stubbornVersion = "3.1.0"
 val prometheusVersion = "0.16.0"
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.30.7"
+ThisBuild / version := "0.30.8"


### PR DESCRIPTION
- awsVersion 2.47.5 -> 2.54.5: AWS SDK BOM pulls netty 4.1.135.Final -> 4.1.137.Final and httpclient5 5.6.2 -> 5.6.4, addressing netty-codec-http/http2 and httpclient5 advisories.
- jacksonVersion 2.21.5 -> 2.21.6: latest patch from Maven Central.
- Bump ThisBuild / version 0.30.7 -> 0.30.8 so a new artifact publishes.